### PR TITLE
Handle unsupport css properties during shorthand expansion.

### DIFF
--- a/packages/opticss/src/Actions/actions/Warning.ts
+++ b/packages/opticss/src/Actions/actions/Warning.ts
@@ -1,0 +1,4 @@
+import { Note } from "./Note";
+
+export class Warning extends Note {
+}

--- a/packages/opticss/src/Actions/index.ts
+++ b/packages/opticss/src/Actions/index.ts
@@ -26,4 +26,5 @@ export { RemoveRule } from "./actions/RemoveRule";
 export { RewriteRuleIdents } from "./actions/RewriteRuleIdents";
 export { MergeDeclarations } from "./actions/MergeDeclarations";
 export { Note } from "./actions/Note";
+export { Warning } from "./actions/Warning";
 export * from "./Action";

--- a/packages/opticss/src/Optimizer.ts
+++ b/packages/opticss/src/Optimizer.ts
@@ -217,39 +217,32 @@ export class Optimizer {
    *   but it is needed to ensure that source maps works correctly.
    * @returns The optimization result.
    */
-  optimize(outputFilename: string): Promise<OptimizationResult> {
+  async optimize(outputFilename: string): Promise<OptimizationResult> {
     let pass = new OptimizationPass(this.options, this.templateOptions);
     let start = new Date();
 
     // Parse all input files.
-    return this.parseFiles(this.sources)
+    let files = await this.parseFiles(this.sources);
 
     // Run all initializers on parsed files.
-    .then(files => {
-      this.initialize(pass, files);
-      return files;
-    })
+    this.initialize(pass, files);
 
     // Run all optimizers on parsed files.
-    .then(files => {
-      return this.optimizeFiles(pass, files);
-    })
+    files = await this.optimizeFiles(pass, files);
 
     // Concatenate all files and return optimization result.
-    .then((files) => {
-      let output = this.concatenateFiles(files, outputFilename);
-      this.logTiming("total", start, new Date());
-      return {
-        output: {
-          filename: outputFilename,
-          content: output.content.toString(),
-          sourceMap: output.sourceMap,
-        },
-        styleMapping: pass.styleMapping,
-        actions: pass.actions,
-      };
-    });
+    let output = this.concatenateFiles(files, outputFilename);
+    this.logTiming("total", start, new Date());
 
+    return {
+      output: {
+        filename: outputFilename,
+        content: output.content.toString(),
+        sourceMap: output.sourceMap,
+      },
+      styleMapping: pass.styleMapping,
+      actions: pass.actions,
+    };
   }
 }
 

--- a/packages/opticss/src/Optimizer.ts
+++ b/packages/opticss/src/Optimizer.ts
@@ -276,7 +276,7 @@ function parseCss(file: CssFile): Promise<ParsedCssFile> {
 }
 
 // This use of this plugin silences a postcss warning.
-export const POSTCSS_NOOP_PLUGIN = postcss.plugin("css-blocks-plugin", function (_opts) {
+export const POSTCSS_NOOP_PLUGIN = postcss.plugin("noop-plugin", function (_opts) {
   return function (_root, _result) {
     return Promise.resolve();
   };

--- a/packages/opticss/src/optimizations/MergeDeclarations/DeclarationMapper.ts
+++ b/packages/opticss/src/optimizations/MergeDeclarations/DeclarationMapper.ts
@@ -118,7 +118,7 @@ export class DeclarationMapper {
             // We only expand shorthand declarations as much as is necessary within the current optimization context
             // but we need to track declarations globally and against elements according to the fully expanded
             // values because selectors can conflict across different optimization contexts.
-            let longhandDeclarations = expandIfNecessary(context.authoredProps, decl.prop, decl.value, pass.actions);
+            let longhandDeclarations = expandIfNecessary(context.authoredProps, decl.prop, decl.value, pass.actions, decl);
             let longHandProps = Object.keys(longhandDeclarations);
             let longHandDeclInfos = new Array<DeclarationInfo>();
             for (let longHandProp of longHandProps) {

--- a/packages/opticss/src/optimizations/MergeDeclarations/index.ts
+++ b/packages/opticss/src/optimizations/MergeDeclarations/index.ts
@@ -402,7 +402,7 @@ export class MergeDeclarations implements MultiFileOptimization {
       if (declInfos.length === 0) {
         continue;
       }
-      let expanded = expandIfNecessary(context.authoredProps, declInfos[0].prop, declInfos[0].value, actions);
+      let expanded = expandIfNecessary(context.authoredProps, declInfos[0].prop, declInfos[0].value, actions, declInfos[0].decl);
       nextMerge:
       for (let unmergedDecl of declInfos) {
         nextGroup:

--- a/packages/opticss/src/util/shorthandProperties.ts
+++ b/packages/opticss/src/util/shorthandProperties.ts
@@ -52,6 +52,9 @@ export function expandIfNecessary(authoredProps: Set<string>, prop: string, valu
     if (/parsing shorthand property/.test(e.message)) {
       actions.perform(new Note("mergeDeclarations", e.message + `(long hands for this declaration will not be optimized)`));
       return { [prop]: value };
+    } else if (/is not a supported property/.test(e.message)) {
+      actions.perform(new Note("mergeDeclarations", e.message + `(long hands for this declaration with conflicting values will not be understood as such which could result in incorrect optimization output.)`));
+      return { [prop]: value };
     } else {
       throw e;
     }

--- a/packages/opticss/test/fixtures/integration-tests/simple/markup.html
+++ b/packages/opticss/test/fixtures/integration-tests/simple/markup.html
@@ -24,9 +24,9 @@
       </tr>
     </tbody>
   </table>
-  <div class="foo-1">
-    <div class="bar"><span class="label">A Label 1</span>: value</div>
-    <div class="bar"><span class="label">A Label 2</span>: value</div>
+  <div class="foo-1 layout-container">
+    <div class="bar layout-child-a"><span class="label">A Label 1</span>: value</div>
+    <div class="bar layout-child-b"><span class="label">A Label 2</span>: value</div>
   </div>
   <div class="foo-2">
     <div class="bar"><span class="label">B Label 1</span>: value</div>

--- a/packages/opticss/test/fixtures/integration-tests/simple/styles.css
+++ b/packages/opticss/test/fixtures/integration-tests/simple/styles.css
@@ -1,4 +1,4 @@
-/* http://meyerweb.com/eric/tools/css/reset/ 
+/* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126
    License: none (public domain)
 */
@@ -12,8 +12,8 @@ b, u, i, center,
 dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
 table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed, 
-figure, figcaption, footer, header, hgroup, 
+article, aside, canvas, details, embed,
+figure, figcaption, footer, header, hgroup,
 menu, nav, output, ruby, section, summary,
 time, mark, audio, video {
 	margin: 0;
@@ -24,7 +24,7 @@ time, mark, audio, video {
 	vertical-align: baseline;
 }
 /* HTML5 display-role reset for older browsers */
-article, aside, details, figcaption, figure, 
+article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
@@ -106,4 +106,16 @@ table {
   font-weight: bold;
 }
 
+.layout-container {
+  display: grid;
+  grid-template: "a b";
+}
+
+.layout-child-a {
+  grid-area: a;
+}
+
+.layout-child-b {
+  grid-area: b;
+}
 

--- a/packages/opticss/test/integration-tests.ts
+++ b/packages/opticss/test/integration-tests.ts
@@ -1,14 +1,15 @@
-import {
-  TestTemplate,
-} from "@opticss/simple-template";
+import { TestTemplate } from "@opticss/simple-template";
+import { assert } from "chai";
 import * as fs from "fs";
 import {
   slow,
   suite,
   test,
-  timeout,
+  timeout
 } from "mocha-typescript";
 import * as path from "path";
+
+import { Warning } from "../src";
 
 import {
   CascadeTestError,
@@ -16,8 +17,9 @@ import {
   debugCascadeError,
   debugError,
   logOptimizations,
-  testOptimizationCascade,
+  testOptimizationCascade
 } from "./util/assertCascade";
+
 // import { debugSize } from "./util/assertSmaller";
 
 function testDefaults(...stylesAndTemplates: Array<string | TestTemplate>): Promise<CascadeTestResult> {
@@ -40,7 +42,12 @@ export class IntegrationTests {
     let css = fs.readFileSync(path.resolve(__dirname, "../../test/fixtures/integration-tests/simple/styles.css"), "utf-8");
     let markup = fs.readFileSync(path.resolve(__dirname, "../../test/fixtures/integration-tests/simple/markup.html"), "utf-8");
     let template = new TestTemplate("test", markup, true);
-    return testDefaults(css, template).then(_result => {
+    return testDefaults(css, template).then(result => {
+      let warnings = result.optimization.actions.performed.filter(a => a instanceof Warning);
+      assert.equal(warnings.length, 3);
+      assert.equal(warnings[0].logString(), `${process.cwd()}/test1.css:111:3 [mergeDeclarations] ` +
+        `Unsupported property error: grid-template is not a supported property ` +
+        `(long hands for this declaration with conflicting values will not be understood as such which could result in incorrect optimization output.)`);
       // logOptimizations(result.optimization);
       // return debugSize(result).then(() => {
       //   // debugResult(css, result);

--- a/packages/opticss/test/integration-tests.ts
+++ b/packages/opticss/test/integration-tests.ts
@@ -5,7 +5,7 @@ import {
   slow,
   suite,
   test,
-  timeout
+  timeout,
 } from "mocha-typescript";
 import * as path from "path";
 
@@ -17,7 +17,7 @@ import {
   debugCascadeError,
   debugError,
   logOptimizations,
-  testOptimizationCascade
+  testOptimizationCascade,
 } from "./util/assertCascade";
 
 // import { debugSize } from "./util/assertSmaller";

--- a/packages/opticss/test/integration-tests.ts
+++ b/packages/opticss/test/integration-tests.ts
@@ -46,7 +46,9 @@ export class IntegrationTests {
       //   // debugResult(css, result);
       // });
     }).catch(e => {
-      logOptimizations(e.optimization);
+      if (e.optimization) {
+        logOptimizations(e.optimization);
+      }
       debugCascadeError(e);
       throw e;
     });


### PR DESCRIPTION
If a shorthand property isn't recognized, keep the value as if it were a long hand property. This means that conflicts won't be detected between the short hand and the long-hand values.